### PR TITLE
use git hooks to run linter pre commit

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,7 @@
     "lint:ci": "eslint . --max-warnings 0 --ext .js,.jsx,.ts,.tsx"
   },
   "eslintConfig": {
-    "extends": ["react-app", "prettier"]
+    "extends": ["react-app", "prettier"],
     "rules": {
         "react/no-danger": "error",
         "react-hooks/exhaustive-deps": "error",

--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,20 @@
     "lint:ci": "eslint . --max-warnings 0 --ext .js,.jsx,.ts,.tsx"
   },
   "eslintConfig": {
-    "extends": "react-app"
+    "extends": ["react-app", "prettier"]
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "src/**/*.{js,jsx,ts,tsx}": [
+      "./node_modules/.bin/eslint --fix"
+    ],
+    "src/**/*.{js,jsx,ts,tsx,css}": [
+      "./node_modules/.bin/prettier --write"
+    ]
   },
   "browserslist": {
     "production": [
@@ -82,6 +95,8 @@
     "eslint-plugin-react-hooks": "^4.1.0",
     "history": "^5.0.0",
     "http-proxy-middleware": "^2.0.0",
+    "husky": "^4.3.6",
+    "lint-staged": "^10.5.3",
     "mutationobserver-shim": "^0.3.7",
     "nock": "^13.1.0",
     "prettier": "^2.3.1",


### PR DESCRIPTION
Changes package.json so that every time someone does a git commit it will run eslint and prettier against the files staged for the commit. Ensuring someone cant commit code that doesn't abide by linter rules.