### PR TITLE
setup csp security and eslint settings

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,15 @@
     "lint:ci": "eslint . --max-warnings 0 --ext .js,.jsx,.ts,.tsx"
   },
   "eslintConfig": {
-    "extends": "react-app"
+    "extends": "react-app",
+    "rules": {
+      "react/no-danger": "error",
+      "react-hooks/exhaustive-deps": "error",
+      "react/jsx-curly-brace-presence": [
+        1,
+        "never"
+      ]
+    }
   },
   "browserslist": {
     "production": [

--- a/src/main/kotlin/events/tracked/tsr/security/CommonSecurityConfigurer.kt
+++ b/src/main/kotlin/events/tracked/tsr/security/CommonSecurityConfigurer.kt
@@ -5,13 +5,22 @@ import org.springframework.security.web.authentication.logout.HeaderWriterLogout
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository
 import org.springframework.security.web.header.writers.ClearSiteDataHeaderWriter
 import org.springframework.stereotype.Component
+import java.util.*
 
 @Component
 class CommonSecurityConfigurer : HttpSecurityConfigurer {
     override fun configure(http: HttpSecurity) {
+        configureCsp(http)
         configureCsrfProtection(http)
         clearBrowserDataOnLogout(http)
         configureXssPreventionHeaders(http)
+    }
+
+    //configure CSP/XSS protection
+    private fun configureCsp(http: HttpSecurity) {
+        val cspParts = StringJoiner(";")
+        cspParts.add("default-src 'self'")
+        http.headers().contentSecurityPolicy(cspParts.toString())
     }
 
     //line gives react the ability to read XSRF tokens


### PR DESCRIPTION
Setup csp security confige

Add Eslint rules:
Dont allow dangerously set html
Only allow react hooks to be used within component level functions
Prevents use of unnecessary curly braces on components